### PR TITLE
Geographic Subject Cleanup

### DIFF
--- a/cleaned_data/modsbypid/wcc:268.xml
+++ b/cleaned_data/modsbypid/wcc:268.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:269.xml
+++ b/cleaned_data/modsbypid/wcc:269.xml
@@ -45,9 +45,12 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85017769">
       <topic>Buildings</topic>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n79109786">
-      <geographic>Knoxville (Tenn.)</geographic>
+   <subject authority="geonames"
+            valueURI="https://sws.geonames.org/4634946/">
+     <geographic>Knoxville (Tenn.)</geographic>
+     <cartographics>
+         <coordinates>35.96064, -83.92074</coordinates>
+     </cartographics>
    </subject>
    <typeOfResource>still image</typeOfResource>
    <relatedItem displayLabel="Project" type="host">

--- a/cleaned_data/modsbypid/wcc:270.xml
+++ b/cleaned_data/modsbypid/wcc:270.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:271.xml
+++ b/cleaned_data/modsbypid/wcc:271.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:272.xml
+++ b/cleaned_data/modsbypid/wcc:272.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:273.xml
+++ b/cleaned_data/modsbypid/wcc:273.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:274.xml
+++ b/cleaned_data/modsbypid/wcc:274.xml
@@ -45,10 +45,13 @@
          <coordinates>35.64148, -83.71517</coordinates>
       </cartographics>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:274.xml
+++ b/cleaned_data/modsbypid/wcc:274.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85137027">
       <topic>Transportation</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4811392">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4635692/">
       <geographic>Laurel Creek</geographic>
       <cartographics>
-         <coordinates>37.85734, -80.99371</coordinates>
+         <coordinates>35.64148, -83.71517</coordinates>
       </cartographics>
    </subject>
    <subject authority="naf"

--- a/cleaned_data/modsbypid/wcc:275.xml
+++ b/cleaned_data/modsbypid/wcc:275.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:277.xml
+++ b/cleaned_data/modsbypid/wcc:277.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:278.xml
+++ b/cleaned_data/modsbypid/wcc:278.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:279.xml
+++ b/cleaned_data/modsbypid/wcc:279.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:280.xml
+++ b/cleaned_data/modsbypid/wcc:280.xml
@@ -43,10 +43,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85114487">
       <topic>Roads</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4811392">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4635692/">
       <geographic>Laurel Creek</geographic>
       <cartographics>
-         <coordinates>37.85734, -80.99371</coordinates>
+         <coordinates>35.64148, -83.71517</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:281.xml
+++ b/cleaned_data/modsbypid/wcc:281.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85062487">
       <topic>Hotels</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:282.xml
+++ b/cleaned_data/modsbypid/wcc:282.xml
@@ -43,10 +43,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85114487">
       <topic>Roads</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4811392">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4635692/">
       <geographic>Laurel Creek</geographic>
       <cartographics>
-         <coordinates>37.85734, -80.99371</coordinates>
+         <coordinates>35.64148, -83.71517</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:283.xml
+++ b/cleaned_data/modsbypid/wcc:283.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:285.xml
+++ b/cleaned_data/modsbypid/wcc:285.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:287.xml
+++ b/cleaned_data/modsbypid/wcc:287.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85058715">
       <topic>Handicraft</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:289.xml
+++ b/cleaned_data/modsbypid/wcc:289.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:290.xml
+++ b/cleaned_data/modsbypid/wcc:290.xml
@@ -43,10 +43,13 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85093565">
       <topic>Oak</topic>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:291.xml
+++ b/cleaned_data/modsbypid/wcc:291.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:292.xml
+++ b/cleaned_data/modsbypid/wcc:292.xml
@@ -43,10 +43,13 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85093565">
       <topic>Oak</topic>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:293.xml
+++ b/cleaned_data/modsbypid/wcc:293.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:294.xml
+++ b/cleaned_data/modsbypid/wcc:294.xml
@@ -35,16 +35,16 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5750895">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4656241/">
       <geographic>Scott Mountain</geographic>
       <cartographics>
-         <coordinates>43.37199, -123.06495</coordinates>
+         <coordinates>35.62509, -83.76962</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5750895">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4656241/">
       <geographic>Scott Mountain</geographic>
       <cartographics>
-         <coordinates>43.37199, -123.06495</coordinates>
+         <coordinates>35.62509, -83.76962</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:295.xml
+++ b/cleaned_data/modsbypid/wcc:295.xml
@@ -43,10 +43,13 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85062487">
       <topic>Hotels</topic>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:296.xml
+++ b/cleaned_data/modsbypid/wcc:296.xml
@@ -35,16 +35,16 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5750895">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4656241/">
       <geographic>Scott Mountain</geographic>
       <cartographics>
-         <coordinates>43.37199, -123.06495</coordinates>
+         <coordinates>35.62509, -83.76962</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5750895">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4656241/">
       <geographic>Scott Mountain</geographic>
       <cartographics>
-         <coordinates>43.37199, -123.06495</coordinates>
+         <coordinates>35.62509, -83.76962</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:297.xml
+++ b/cleaned_data/modsbypid/wcc:297.xml
@@ -39,10 +39,13 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85062487">
       <topic>Hotels</topic>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:302.xml
+++ b/cleaned_data/modsbypid/wcc:302.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:303.xml
+++ b/cleaned_data/modsbypid/wcc:303.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="naf"

--- a/cleaned_data/modsbypid/wcc:303.xml
+++ b/cleaned_data/modsbypid/wcc:303.xml
@@ -41,10 +41,13 @@
          <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:304.xml
+++ b/cleaned_data/modsbypid/wcc:304.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85137027">
       <topic>Transportation</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:305.xml
+++ b/cleaned_data/modsbypid/wcc:305.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="naf"

--- a/cleaned_data/modsbypid/wcc:305.xml
+++ b/cleaned_data/modsbypid/wcc:305.xml
@@ -41,10 +41,13 @@
          <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:306.xml
+++ b/cleaned_data/modsbypid/wcc:306.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:307.xml
+++ b/cleaned_data/modsbypid/wcc:307.xml
@@ -41,10 +41,10 @@
          <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:307.xml
+++ b/cleaned_data/modsbypid/wcc:307.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">

--- a/cleaned_data/modsbypid/wcc:308.xml
+++ b/cleaned_data/modsbypid/wcc:308.xml
@@ -45,10 +45,10 @@
          <coordinates>35.68203, -83.79045</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4711528">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
       <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>33.15623, -95.11438</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:309.xml
+++ b/cleaned_data/modsbypid/wcc:309.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:310.xml
+++ b/cleaned_data/modsbypid/wcc:310.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">

--- a/cleaned_data/modsbypid/wcc:310.xml
+++ b/cleaned_data/modsbypid/wcc:310.xml
@@ -41,10 +41,10 @@
          <coordinates>33.70054, -94.23434</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4711528">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
       <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>33.15623, -95.11438</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:311.xml
+++ b/cleaned_data/modsbypid/wcc:311.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85136805">
       <topic>Trails</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:312.xml
+++ b/cleaned_data/modsbypid/wcc:312.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:314.xml
+++ b/cleaned_data/modsbypid/wcc:314.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/5432425">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4644686/">
       <geographic>Mount Nebo</geographic>
       <cartographics>
-         <coordinates>37.67611, -107.50839</coordinates>
+         <coordinates>35.72902, -83.82622</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:316.xml
+++ b/cleaned_data/modsbypid/wcc:316.xml
@@ -47,10 +47,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:317.xml
+++ b/cleaned_data/modsbypid/wcc:317.xml
@@ -44,10 +44,10 @@
          <coordinates>35.18286, -85.98859</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:317.xml
+++ b/cleaned_data/modsbypid/wcc:317.xml
@@ -38,10 +38,10 @@
    <subject authority="lcsh" valueURI="">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4641907">
-      <geographic>Miller Cove</geographic>
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
+      <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>35.18286, -85.98859</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">

--- a/cleaned_data/modsbypid/wcc:318.xml
+++ b/cleaned_data/modsbypid/wcc:318.xml
@@ -43,10 +43,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:319.xml
+++ b/cleaned_data/modsbypid/wcc:319.xml
@@ -49,10 +49,10 @@
          <coordinates>35.18286, -85.98859</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:319.xml
+++ b/cleaned_data/modsbypid/wcc:319.xml
@@ -43,10 +43,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4641907">
-      <geographic>Miller Cove</geographic>
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
+      <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>35.18286, -85.98859</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">

--- a/cleaned_data/modsbypid/wcc:321.xml
+++ b/cleaned_data/modsbypid/wcc:321.xml
@@ -45,10 +45,10 @@
          <coordinates>35.18286, -85.98859</coordinates>
       </cartographics>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:321.xml
+++ b/cleaned_data/modsbypid/wcc:321.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4641907">
-      <geographic>Miller Cove</geographic>
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
+      <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>35.18286, -85.98859</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">

--- a/cleaned_data/modsbypid/wcc:329.xml
+++ b/cleaned_data/modsbypid/wcc:329.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4641907">
-      <geographic>Miller Cove</geographic>
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
+      <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>35.18286, -85.98859</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:330.xml
+++ b/cleaned_data/modsbypid/wcc:330.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:332.xml
+++ b/cleaned_data/modsbypid/wcc:332.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh2003004821">
       <topic>Bodies of water</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:333.xml
+++ b/cleaned_data/modsbypid/wcc:333.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:335.xml
+++ b/cleaned_data/modsbypid/wcc:335.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/2153081">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4649562/">
       <geographic>Pine Mountain</geographic>
       <cartographics>
-         <coordinates>-33.8318, 148.8512</coordinates>
+         <coordinates>35.59647, -83.91907</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:339.xml
+++ b/cleaned_data/modsbypid/wcc:339.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85078077">
       <topic>Log cabins</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4641907">
-      <geographic>Miller Cove</geographic>
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
+      <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>35.18286, -85.98859</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:340.xml
+++ b/cleaned_data/modsbypid/wcc:340.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85047299">
       <topic>Farms</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4641907">
-      <geographic>Miller Cove</geographic>
+   <subject authority="geonames" valueURI="https://sws.geonames.org/4641903/">
+      <geographic>Millers Cove</geographic>
       <cartographics>
-         <coordinates>35.18286, -85.98859</coordinates>
+         <coordinates>35.70842, -83.82434</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:344.xml
+++ b/cleaned_data/modsbypid/wcc:344.xml
@@ -39,10 +39,13 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85062603">
       <topic>Housing</topic>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n81025935">
-      <geographic>Blount County (Tenn.)</geographic>
-   </subject>
+  <subject authority="geonames"
+         valueURI="https://sws.geonames.org/4607192/">
+   <geographic>Blount County (Tenn.)</geographic>
+    <cartographics>
+        <coordinates>35.68724, -83.92553</coordinates>
+    </cartographics>
+  </subject>
    <subject authority="lcsh"
             valueURI="http://id.loc.gov/authorities/subjects/sh85057008">
       <geographic>Great Smoky Mountains (N.C. and Tenn.)</geographic>

--- a/cleaned_data/modsbypid/wcc:351.xml
+++ b/cleaned_data/modsbypid/wcc:351.xml
@@ -39,10 +39,10 @@
             valueURI="http://id.loc.gov/authorities/subjects/sh85117790">
       <topic>Sawmills</topic>
    </subject>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:354.xml
+++ b/cleaned_data/modsbypid/wcc:354.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:355.xml
+++ b/cleaned_data/modsbypid/wcc:355.xml
@@ -35,10 +35,10 @@
    <physicalDescription>
       <form authority="aat" valueURI="http://vocab.getty.edu/aat/300046300">photographs</form>
    </physicalDescription>
-   <subject authority="geonames" valueURI="http://sws.geonames.org/4119374">
+   <subject authority="geonames" valueURI="https://sws.geonames.org/9884945/">
       <geographic>Little River</geographic>
       <cartographics>
-         <coordinates>33.70054, -94.23434</coordinates>
+         <coordinates>35.65304, -83.56978</coordinates>
       </cartographics>
    </subject>
    <subject authority="lcsh"

--- a/cleaned_data/modsbypid/wcc:356.xml
+++ b/cleaned_data/modsbypid/wcc:356.xml
@@ -41,9 +41,19 @@
          <namePart>University of Tennessee (Knoxville campus)</namePart>
       </name>
    </subject>
-   <subject authority="naf"
-            valueURI="http://id.loc.gov/authorities/names/n79109786">
+   <subject authority="geonames"
+            valueURI="https://sws.geonames.org/4634946/">
       <geographic>Knoxville (Tenn.)</geographic>
+      <cartographics>
+         <coordinates>35.96064, -83.92074</coordinates>
+      </cartographics>
+   </subject>
+   <subject authority="geonames"
+            valueURI="https://sws.geonames.org/4664275/">
+      <geographic>University of Tennessee</geographic>
+      <cartographics>
+         <coordinates>35.95425, -83.93074</coordinates>
+      </cartographics>
    </subject>
    <typeOfResource>still image</typeOfResource>
    <relatedItem displayLabel="Project" type="host">


### PR DESCRIPTION
# What does this do

This does a few things:

1. Replaces geographic subject URIs and Cartographics for subjects that point at the wrong area.
2. Uses URIs that match the name of the graph for the thing that was changed.
3. Changes Miller Cove to MIllers Cove.  From looking at the affected record, this looks like it was a mistake originally?

# What are the results

Originally, this collection had geographic locations all over the world:
<img width="1084" alt="Screenshot 2023-05-27 at 11 01 03 AM" src="https://github.com/UTKcataloging/wcc/assets/2692416/fbcb91af-8f6d-4c52-9572-e592eb1d99ff">

Now the geographic locations more accurately depict Cox Cochran's visit to Tennessee:

<img width="1512" alt="Screenshot 2023-05-28 at 8 44 27 AM" src="https://github.com/UTKcataloging/wcc/assets/2692416/546aefcc-2b2b-4cf0-a786-c5869397be7b">

